### PR TITLE
Migrations:

### DIFF
--- a/scalafix/input/src/main/scala/fix/MigrateEither2.scala
+++ b/scalafix/input/src/main/scala/fix/MigrateEither2.scala
@@ -8,6 +8,7 @@ package fix
 
 import scalaz._
 import Scalaz._
+import scalaz.Scalaz._
 
 object Mylibrary_1_0_Test2 {
   def myMethod(x: Int): String \/ Int =

--- a/scalafix/input/src/main/scala/fix/MigrateValidation.scala
+++ b/scalafix/input/src/main/scala/fix/MigrateValidation.scala
@@ -1,0 +1,24 @@
+/*
+rule = "class:fix.MigrateValidation"
+*/
+package fix
+
+import scalaz.{ Success, Failure, Validation }
+
+object Validation_1_0_Test {
+  def myMethod(x: Int): Validation[String, Int] =
+    if (x > 2) Success(x)
+    else Failure("wat")
+
+  def myMethod2(x: Int): Validation[String, Int] = ???
+
+  myMethod(43) match {
+    case Success(n) => println(n)
+    case Failure(s) => println(s)
+  }
+
+  myMethod2(1) match {
+    case scalaz.Success(n) => println(n)
+    case scalaz.Failure(s) => println(s)
+  }
+}

--- a/scalafix/input/src/main/scala/fix/MigrateValidationNel.scala
+++ b/scalafix/input/src/main/scala/fix/MigrateValidationNel.scala
@@ -1,0 +1,37 @@
+/*
+rule = "class:fix.MigrateValidationNel"
+*/
+package fix
+
+import scalaz.{ Success, Failure, ValidationNel, NonEmptyList }
+import scalaz.syntax.validation._
+import scalaz.syntax.apply._
+
+object ValidationNel_1_0_Test {
+  def myMethod(x: Int): ValidationNel[String, Int] =
+    if (x > 2) x.successNel[String]
+    else "wat".failureNel[Int]
+
+  def myMethod2(
+    r1: ValidationNel[String, Int],
+    r2: ValidationNel[String, Int]
+  ): ValidationNel[String, Int] =
+    (r1 |@| r2)((b1, b2) => b1 + b2)
+
+  def myMethod3(
+    r1: ValidationNel[String, Int],
+    r2: ValidationNel[String, Int]
+  ): ValidationNel[String, Int] =
+    (r1 |@| r2 |@| r2 |@| r1 |@| r1)((b1, b2, _, _, _) => b1 + b2)
+
+  def myMethod4(x: Int): ValidationNel[String, Int] =
+    if (x > 10) Success(x)
+    else if (x > 5) Failure(NonEmptyList("wat"))
+    else if (x > 3) Failure(NonEmptyList("wat", "wat"))
+    else Failure(NonEmptyList("wat", "wat", "wat"))
+
+  myMethod(43) match {
+    case Success(n) => println(n)
+    case Failure(s) => println(s)
+  }
+}

--- a/scalafix/output/src/main/scala/fix/MigrateValidation.scala
+++ b/scalafix/output/src/main/scala/fix/MigrateValidation.scala
@@ -1,0 +1,22 @@
+package fix
+
+import cats.data.Validated
+import cats.data.Validated.{ Invalid, Valid }
+
+object Validation_1_0_Test {
+  def myMethod(x: Int): Validated[String, Int] =
+    if (x > 2) Valid(x)
+    else Invalid("wat")
+
+  def myMethod2(x: Int): Validated[String, Int] = ???
+
+  myMethod(43) match {
+    case Valid(n) => println(n)
+    case Invalid(s) => println(s)
+  }
+
+  myMethod2(1) match {
+    case Validated.Valid(n) => println(n)
+    case Validated.Invalid(s) => println(s)
+  }
+}

--- a/scalafix/output/src/main/scala/fix/MigrateValidationNel.scala
+++ b/scalafix/output/src/main/scala/fix/MigrateValidationNel.scala
@@ -1,0 +1,35 @@
+package fix
+
+import cats.syntax.validated._
+import cats.syntax.apply._
+import cats.data.{ NonEmptyList, ValidatedNel }
+import cats.data.Validated.{ Invalid, Valid }
+
+object ValidationNel_1_0_Test {
+  def myMethod(x: Int): ValidatedNel[String, Int] =
+    if (x > 2) x.validNel[String]
+    else "wat".invalidNel[Int]
+
+  def myMethod2(
+    r1: ValidatedNel[String, Int],
+    r2: ValidatedNel[String, Int]
+  ): ValidatedNel[String, Int] =
+    (r1, r2).mapN((b1, b2) => b1 + b2)
+
+  def myMethod3(
+    r1: ValidatedNel[String, Int],
+    r2: ValidatedNel[String, Int]
+  ): ValidatedNel[String, Int] =
+    (r1, r2, r2, r1, r1).mapN((b1, b2, _, _, _) => b1 + b2)
+
+  def myMethod4(x: Int): ValidatedNel[String, Int] =
+    if (x > 10) Valid(x)
+    else if (x > 5) Invalid(NonEmptyList.of("wat"))
+    else if (x > 3) Invalid(NonEmptyList.of("wat", "wat"))
+    else Invalid(NonEmptyList.of("wat", "wat", "wat"))
+
+  myMethod(43) match {
+    case Valid(n) => println(n)
+    case Invalid(s) => println(s)
+  }
+}

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.7")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
-
+addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")

--- a/scalafix/rules/src/main/scala/fix/Scalaz2cats_v1_0_0.scala
+++ b/scalafix/rules/src/main/scala/fix/Scalaz2cats_v1_0_0.scala
@@ -114,10 +114,11 @@ case class MigrateValidationNel(index: SemanticdbIndex) extends SemanticRule(ind
         ctx.replaceTree(t, importer"cats.syntax.validated._".syntax)
       case t @ importer"scalaz.syntax.apply._" =>
         ctx.replaceTree(t, importer"cats.syntax.apply._".syntax)
-      case t @ importer"scalaz.{..$ips}" if ips.collect { case i: Importee.Name =>
-        i.name.value }.contains("NonEmptyList") =>
-        ctx.removeImportee(ips.collect { case i: Importee.Name if i.name.value == "NonEmptyList" => i }.head) +
-        ctx.addGlobalImport(importer"cats.data.NonEmptyList")
+      case t @ importer"scalaz.{..$ips}" =>
+        ips.collect {
+          case NonEmptyListScalaz(i: Importee) =>
+            ctx.removeImportee(i) + ctx.addGlobalImport(importer"cats.data.NonEmptyList")
+        }.asPatch
       case Term.ApplyInfix(_, cartesianBuilders(op: Term.Name), _, _) =>
         replaceOpWithComma(ctx, op)
       case Term.Apply(t @ Term.ApplyInfix(_, cartesianBuilders(_), _, _), _) =>

--- a/scalafix/rules/src/main/scala/fix/Scalaz2cats_v1_0_0.scala
+++ b/scalafix/rules/src/main/scala/fix/Scalaz2cats_v1_0_0.scala
@@ -146,6 +146,8 @@ case class RemoveGlobalImports(index: SemanticdbIndex) extends SemanticRule(inde
         ctx.removeImportee(t.asInstanceOf[Importer].importees.head)
       case t @ importer"Scalaz._" =>
         ctx.removeImportee(t.asInstanceOf[Importer].importees.head)
+      case t @ importer"scalaz.Scalaz._" =>
+        ctx.removeImportee(t.asInstanceOf[Importer].importees.head)
     }.asPatch
   }
 }

--- a/scalafix/rules/src/main/scala/fix/Scalaz2cats_v1_0_0.scala
+++ b/scalafix/rules/src/main/scala/fix/Scalaz2cats_v1_0_0.scala
@@ -1,7 +1,8 @@
 package fix
 
 import scalafix._
-import scalafix.util._
+import scalafix.syntax._
+import scalafix.util.SymbolMatcher
 import scala.meta._
 import scala.meta.contrib._
 
@@ -75,6 +76,66 @@ case class MigrateOptionSyntax(index: SemanticdbIndex) extends SemanticRule(inde
       case t @ Term.Select(_, some(_) | none (_))
         if !ctx.tree.contains(scalazOptionSyntaxImport) && !ctx.tree.contains(scalazOptionImport) => ()
     }.length > 0) ctx.addGlobalImport(catsOptionSyntaxImport) else Patch.empty)
+  }
+}
+
+case class MigrateValidationNel(index: SemanticdbIndex) extends SemanticRule(index, "MigrateValidationNel") {
+  private lazy val NonEmptyListScalaz = SymbolMatcher.normalized(
+    Symbol("_root_.scalaz.NonEmptyList.")
+  )
+
+  // blame scalaz/core/src/main/scala/scalaz/syntax/ApplicativeBuilder.scala for this
+  private[this] val cartesianBuilders = SymbolMatcher.normalized((
+    "_root_.scalaz.syntax.ApplyOps.`|@|`." ::
+    "_root_.scalaz.syntax.ApplicativeBuilder.`|@|`." ::
+      (3 to 12).map { i: Int =>
+        val post = (3 to i).map { j => s"ApplicativeBuilder$j" }.mkString(".")
+        s"_root_.scalaz.syntax.ApplicativeBuilder.$post.`|@|`."
+    }.toList).map(Symbol.apply): _*)
+
+  private[this] def replaceOpWithComma(ctx: RuleCtx, op: Term.Name): Patch =
+    // replace |@| with ,
+    ctx.replaceTree(op, ",") ++
+      // remove the space before |@|
+      ctx.tokenList
+        .leading(op.tokens.head)
+        .takeWhile(_.is[Whitespace])
+        .map(ctx.removeToken)
+
+  override def fix(ctx: RuleCtx): Patch = {
+    ctx.replaceSymbols(
+      "scalaz.ValidationNel" -> "cats.data.ValidatedNel",
+      "scalaz.Success" -> "cats.data.Validated.Valid",
+      "scalaz.Failure" -> "cats.data.Validated.Invalid",
+      "scalaz.syntax.ValidationOps.successNel" -> "validNel",
+      "scalaz.syntax.ValidationOps.failureNel" -> "invalidNel"
+    ) + ctx.tree.collect {
+      case t @ importer"scalaz.syntax.validation._" =>
+        ctx.replaceTree(t, importer"cats.syntax.validated._".syntax)
+      case t @ importer"scalaz.syntax.apply._" =>
+        ctx.replaceTree(t, importer"cats.syntax.apply._".syntax)
+      case t @ importer"scalaz.{..$ips}" if ips.collect { case i: Importee.Name =>
+        i.name.value }.contains("NonEmptyList") =>
+        ctx.removeImportee(ips.collect { case i: Importee.Name if i.name.value == "NonEmptyList" => i }.head) +
+        ctx.addGlobalImport(importer"cats.data.NonEmptyList")
+      case Term.ApplyInfix(_, cartesianBuilders(op: Term.Name), _, _) =>
+        replaceOpWithComma(ctx, op)
+      case Term.Apply(t @ Term.ApplyInfix(_, cartesianBuilders(_), _, _), _) =>
+        ctx.addRight(t, ".mapN")
+      case Term.Apply(NonEmptyListScalaz(t), _) =>
+        val x = ctx.tokenList.next(t.tokens.last)
+        ctx.addRight(t, ".of")
+    }.asPatch
+  }
+}
+
+case class MigrateValidation(index: SemanticdbIndex) extends SemanticRule(index, "MigrateValidation") {
+  override def fix(ctx: RuleCtx): Patch = {
+    ctx.replaceSymbols(
+      "scalaz.Validation" -> "cats.data.Validated",
+      "scalaz.Success" -> "cats.data.Validated.Valid",
+      "scalaz.Failure" -> "cats.data.Validated.Invalid"
+    )
   }
 }
 


### PR DESCRIPTION
- Validation symbols (Success,Failure,Validation)
- .successNel/.failureNel syntax
- (r1 |@| r2)((...)=>...) syntax to (r1, r2).mapN((...)=>...)
- NonEmptyList (using .of)
- add scalaz.Scalaz._ to removed global imports