### PR TITLE
Improve cartesian rewrite rule for several cases.

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -8,11 +8,11 @@ lazy val rules = project.settings(
 
 lazy val input = project.settings(
   scalafixSourceroot := sourceDirectory.in(Compile).value,
-  libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.2.15"
+  libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.2.18"
 )
 
 lazy val output = project.settings(
-  libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.0-MF"
+  libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.1"
 )
 
 lazy val tests = project

--- a/scalafix/input/src/main/scala/fix/MigrateValidationNel.scala
+++ b/scalafix/input/src/main/scala/fix/MigrateValidationNel.scala
@@ -30,6 +30,14 @@ object ValidationNel_1_0_Test {
     else if (x > 3) Failure(NonEmptyList("wat", "wat"))
     else Failure(NonEmptyList("wat", "wat", "wat"))
 
+  def myMethod5(r1: ValidationNel[String, Int],
+                r2: ValidationNel[String, Int]): ValidationNel[String, Int] =
+    (r1 |@| r2 |@| r2 |@| r1 |@| r1).apply((b1, b2, _, _, _) => b1 + b2)
+
+  def myMethod6(r1: ValidationNel[String, Int],
+                r2: ValidationNel[String, Int]): ValidationNel[String, Int] =
+    r1 |@| r2 |@| r2 |@| r1 |@| r1 apply ((b1, b2, _, _, _) => b1 + b2)
+
   myMethod(43) match {
     case Success(n) => println(n)
     case Failure(s) => println(s)

--- a/scalafix/input/src/main/scala/fix/MigrateValidationNel.scala
+++ b/scalafix/input/src/main/scala/fix/MigrateValidationNel.scala
@@ -38,6 +38,13 @@ object ValidationNel_1_0_Test {
                 r2: ValidationNel[String, Int]): ValidationNel[String, Int] =
     r1 |@| r2 |@| r2 |@| r1 |@| r1 apply ((b1, b2, _, _, _) => b1 + b2)
 
+  def myMethod7(r1: ValidationNel[String, Int],
+                r2: ValidationNel[String, Int]): ValidationNel[String, Int] =
+    r1 |@| r2 apply f2
+
+
+  def f2(str1: Int, str2: Int): Int = str1 + str2
+
   myMethod(43) match {
     case Success(n) => println(n)
     case Failure(s) => println(s)

--- a/scalafix/output/src/main/scala/fix/MigrateValidationNel.scala
+++ b/scalafix/output/src/main/scala/fix/MigrateValidationNel.scala
@@ -28,6 +28,14 @@ object ValidationNel_1_0_Test {
     else if (x > 3) Invalid(NonEmptyList.of("wat", "wat"))
     else Invalid(NonEmptyList.of("wat", "wat", "wat"))
 
+  def myMethod5(r1: ValidatedNel[String, Int],
+                r2: ValidatedNel[String, Int]): ValidatedNel[String, Int] =
+    (r1, r2, r2, r1, r1).mapN((b1, b2, _, _, _) => b1 + b2)
+
+  def myMethod6(r1: ValidatedNel[String, Int],
+                r2: ValidatedNel[String, Int]): ValidatedNel[String, Int] =
+    (r1, r2, r2, r1, r1) mapN ((b1, b2, _, _, _) => b1 + b2)
+
   myMethod(43) match {
     case Valid(n) => println(n)
     case Invalid(s) => println(s)

--- a/scalafix/output/src/main/scala/fix/MigrateValidationNel.scala
+++ b/scalafix/output/src/main/scala/fix/MigrateValidationNel.scala
@@ -36,6 +36,13 @@ object ValidationNel_1_0_Test {
                 r2: ValidatedNel[String, Int]): ValidatedNel[String, Int] =
     (r1, r2, r2, r1, r1) mapN ((b1, b2, _, _, _) => b1 + b2)
 
+  def myMethod7(r1: ValidatedNel[String, Int],
+                r2: ValidatedNel[String, Int]): ValidatedNel[String, Int] =
+    (r1, r2) mapN f2
+
+
+  def f2(str1: Int, str2: Int): Int = str1 + str2
+
   myMethod(43) match {
     case Valid(n) => println(n)
     case Invalid(s) => println(s)


### PR DESCRIPTION
- Improve cartesian rewrite rule for several cases.
`(r1 |@| r2).apply((b1, b2) => b1 + b2) ` -> `(r1, r2).mapN((b1, b2) => b1 + b2)`
`r1 |@| r2 apply ((b1, b2) => b1 + b2)` -> `(r1, r2) mapN ((b1, b2) => b1 + b2)`

- Upgraded scalaz and cats to the latest version
- Some minor clean up