### PR TITLE
#12 Draft fix for errors on newer versions of Scala/SBT

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ Automatic migrations from scalaz 7 to cats 1.0.
 > If a general migration from Scalaz to Cats is needed in the community,
 > feel free to [follow the issue in the Cats repo](https://github.com/typelevel/cats/issues/1762).
 
+## Running
+
+Make sure you add this to `plugins.sbt`
+
+    addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.24")
+
+
+If you first run `sbt`, you can run the following
+
+    scalafix github:gabro/scalaz2cats/Scalaz2cats_v1_0_0
+
+Otherwise, from the terminal, you can run this
+
+    sbt ";scalafixEnable; scalafix github:gabro/scalaz2cats/Scalaz2cats_v1_0_0"
+
+
 ## Contribution guide
 Follow the [guide on the Scalafix website](https://scalacenter.github.io/scalafix/docs/rule-authors/setup).
 As a quick-start, you can run the tests by doing:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Otherwise, from the terminal, you can run this
 
 
 ## Contribution guide
-Follow the [guide on the Scalafix website](https://scalacenter.github.io/scalafix/docs/rule-authors/setup).
+Follow the [guide on the Scalafix website](https://scalacenter.github.io/scalafix/docs/developers/setup.html).
 As a quick-start, you can run the tests by doing:
 
 ```bash

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,33 +1,54 @@
-lazy val V = _root_.scalafix.Versions
-// Use a scala version supported by scalafix.
-scalaVersion in ThisBuild := V.scala212
+lazy val V = _root_.scalafix.sbt.BuildInfo
+inThisBuild(
+  List(
+    scalaVersion := V.scala212,
+    crossScalaVersions := List(V.scala213, V.scala212, V.scala211),
+    organization := "com.example",
+    homepage := Some(url("https://github.com/com/example")),
+    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    developers := List(
+      Developer(
+        "example-username",
+        "Example Full Name",
+        "example@email.com",
+        url("https://example.com")
+      )
+    ),
+    addCompilerPlugin(scalafixSemanticdb),
+    scalacOptions ++= List(
+      "-Yrangepos",
+      "-P:semanticdb:synthetics:on"
+    )
+  )
+)
+
+skip in publish := true
 
 lazy val rules = project.settings(
-  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.version
+  moduleName := "scalafix",
+  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
 )
 
 lazy val input = project.settings(
-  scalafixSourceroot := sourceDirectory.in(Compile).value,
-  libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.2.18"
+  skip in publish := true
 )
 
 lazy val output = project.settings(
-  libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.1",
-  libraryDependencies += "org.typelevel" %% "mouse" % "0.16"
+  skip in publish := true
 )
 
 lazy val tests = project
   .settings(
-    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.version % Test cross CrossVersion.full,
-    buildInfoPackage := "fix",
-    buildInfoKeys := Seq[BuildInfoKey](
-      "inputSourceroot" ->
-        sourceDirectory.in(input, Compile).value,
-      "outputSourceroot" ->
-        sourceDirectory.in(output, Compile).value,
-      "inputClassdirectory" ->
-        classDirectory.in(input, Compile).value
-    )
+    skip in publish := true,
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
+    compile.in(Compile) := 
+      compile.in(Compile).dependsOn(compile.in(input, Compile)).value,
+    scalafixTestkitOutputSourceDirectories :=
+      unmanagedSourceDirectories.in(output, Compile).value,
+    scalafixTestkitInputSourceDirectories :=
+      unmanagedSourceDirectories.in(input, Compile).value,
+    scalafixTestkitInputClasspath :=
+      fullClasspath.in(input, Compile).value,
   )
-  .dependsOn(input, rules)
-  .enablePlugins(BuildInfoPlugin)
+  .dependsOn(rules)
+  .enablePlugins(ScalafixTestkitPlugin)

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -3,23 +3,15 @@ inThisBuild(
   List(
     scalaVersion := V.scala212,
     crossScalaVersions := List(V.scala213, V.scala212, V.scala211),
-    organization := "com.example",
-    homepage := Some(url("https://github.com/com/example")),
-    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
-    developers := List(
-      Developer(
-        "example-username",
-        "Example Full Name",
-        "example@email.com",
-        url("https://example.com")
-      )
-    ),
+    organization := "gabro",
+    homepage := Some(url("https://github.com/gabro/scalaz2cats")),
     addCompilerPlugin(scalafixSemanticdb),
     scalacOptions ++= List(
       "-Yrangepos",
       "-P:semanticdb:synthetics:on"
     )
   )
+)
 )
 
 skip in publish := true
@@ -30,10 +22,13 @@ lazy val rules = project.settings(
 )
 
 lazy val input = project.settings(
+  libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.2.18",
   skip in publish := true
 )
 
 lazy val output = project.settings(
+  libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.1",
+  libraryDependencies += "org.typelevel" %% "mouse" % "0.16",
   skip in publish := true
 )
 
@@ -52,3 +47,4 @@ lazy val tests = project
   )
   .dependsOn(rules)
   .enablePlugins(ScalafixTestkitPlugin)
+  .enablePlugins(BuildInfoPlugin)

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -12,7 +12,6 @@ inThisBuild(
     )
   )
 )
-)
 
 skip in publish := true
 

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.3.13

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,4 +1,5 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.7")
+resolvers += Resolver.sonatypeRepo("releases")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.24")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")

--- a/scalafix/rules/src/main/scala/fix/Scalaz2cats_v1_0_0.scala
+++ b/scalafix/rules/src/main/scala/fix/Scalaz2cats_v1_0_0.scala
@@ -1,9 +1,9 @@
 package fix
 
 import fix.ScalafixUtils._
-import scalafix._
-import scalafix.syntax._
 import scalafix.util.SymbolMatcher
+import scalafix.v0._
+
 import scala.meta._
 import scala.meta.contrib._
 

--- a/scalafix/tests/src/test/scala/fix/Mylibrary_Tests.scala
+++ b/scalafix/tests/src/test/scala/fix/Mylibrary_Tests.scala
@@ -1,14 +1,8 @@
 package fix
 
-import scala.meta._
-import scalafix._
+import org.scalatest.FunSuiteLike
 import scalafix.testkit._
 
-class Mylibrary_Tests
-  extends SemanticRewriteSuite(
-    SemanticdbIndex.load(Classpath(AbsolutePath(BuildInfo.inputClassdirectory))),
-    AbsolutePath(BuildInfo.inputSourceroot),
-    Seq(AbsolutePath(BuildInfo.outputSourceroot))
-  ) {
+class Mylibrary_Tests extends AbstractSemanticRuleSuite with FunSuiteLike {
   runAllTests()
 }


### PR DESCRIPTION
Finally got round to looking at #12 

I updated the project in line with the latest Gitter template for scalafix. I fixed the specific error in #12 by refering to the old API (b1ba6cd) but cam unstuck with references to `SemanticRewriteSuite` which no longer compiled. I took a chance and tried using a regular test suite which seems to run the tests but there are a bunch of errors I don't understand (as to why the tests fail).

I was hoping you could take a look and if its a simple fix, that you'd be able to merge the PR and tweak whatever's required.

🙏 